### PR TITLE
Update README.rst to render properly.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ mnm
 
 Mastodon Network Monitoring: track and display browsable stats about Mastodon network (instances, toots, users...).
 
-Public instance available here: [https://mnm.eliotberriot.com](https://mnm.eliotberriot.com)
+Public instance available here: https://mnm.eliotberriot.com
 
 .. image:: https://img.shields.io/badge/built%20with-Cookiecutter%20Django-ff69b4.svg
      :target: https://github.com/pydanny/cookiecutter-django/


### PR DESCRIPTION
The brackets and parentheses showed up literally and enclosed an invalid link before. I hope this helps!

Thanks,
@EtherTyper